### PR TITLE
fix(config): 修复跨平台输出路径中用户主目录的正确扩展

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Empty path",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Absolute path",
+			input:    "/absolute/path",
+			expected: "/absolute/path",
+		},
+		{
+			name:     "Relative path",
+			input:    "relative/path",
+			expected: "relative/path",
+		},
+		{
+			name:     "Home directory only",
+			input:    "~",
+			expected: home,
+		},
+		{
+			name:     "Home directory with forward slash",
+			input:    "~/Downloads",
+			expected: filepath.Join(home, "Downloads"),
+		},
+		{
+			name:     "Home directory with backslash (simulated)",
+			input:    `~\Downloads`,
+			expected: filepath.Join(home, "Downloads"),
+		},
+		{
+			name:     "Invalid tilde use (middle)",
+			input:    "/path/~/test",
+			expected: "/path/~/test",
+		},
+		{
+			name:     "Invalid tilde use (no separator)",
+			input:    "~user",
+			expected: "~user", // We don't support ~user expansion currently
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandPath(tt.input)
+			if got != tt.expected {
+				t.Errorf("expandPath(%q) = %q; want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 路径问题修复
此 PR 修复了一个 bug：当 `output_dir` 配置使用 `~/`（波浪号）时，未能正确扩展为用户主目录的路径，从而导致下载失败或在当前目录下错误地创建了名为 `~` 的文件夹

## 变更内容
- 在 `internal/config/config.go` 中添加了 `expandPath` 辅助函数来处理 `~/` 的路径扩展
- 增加了跨平台支持，可以处理 `/` 和 `\` 两种路径分隔符（解决了 Windows 用户和 macOS 用户混用分隔符的问题）
-  在 `internal/config/config_test.go` 中添加了单元测试以验证逻辑的正确性

## 相关问题
修复 [#11 提及的路径问题](https://github.com/guiyumin/vget/issues/11#issuecomment-3640326283)
<img width="1784" height="714" alt="CleanShot 2025-12-11 at 13 59 35@2x" src="https://github.com/user-attachments/assets/e9ec57d4-ea98-4742-af74-94f4673febe8" />
