### PR TITLE
feat: detect image type by magic bytes

### DIFF
--- a/internal/core/downloader/magic.go
+++ b/internal/core/downloader/magic.go
@@ -1,0 +1,52 @@
+package downloader
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+// DetectFileType reads the first few bytes of the file to determine its type
+// Returns the suggested extension (without dot) if detected, or empty string if unknown
+func DetectFileType(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	// Read first 12 bytes
+	// WEBP needs at least 12 bytes: "RIFF" + 4 bytes size + "WEBP"
+	header := make([]byte, 12)
+	n, err := f.Read(header)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	if n < 4 {
+		return "", nil // Too short
+	}
+
+	// Check magic bytes
+
+	// WebP: RIFF....WEBP
+	if n >= 12 && string(header[0:4]) == "RIFF" && string(header[8:12]) == "WEBP" {
+		return "webp", nil
+	}
+
+	// PNG: 89 50 4E 47 0D 0A 1A 0A
+	if n >= 8 && bytes.Equal(header[0:8], []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}) {
+		return "png", nil
+	}
+
+	// GIF: GIF87a or GIF89a
+	if n >= 6 && (string(header[0:6]) == "GIF87a" || string(header[0:6]) == "GIF89a") {
+		return "gif", nil
+	}
+
+	// JPEG: FF D8 FF
+	if n >= 3 && bytes.Equal(header[0:3], []byte{0xFF, 0xD8, 0xFF}) {
+		return "jpg", nil
+	}
+
+	return "", nil
+}


### PR DESCRIPTION
  ## Background

  - XHS  downloads were defaulting to .jpg even when the actual image format was webp/png/gif, which leads to confusing file extensions and viewers misinterpreting the files.

 ## Summary
  - Detect downloaded image type via magic bytes and fix mismatched extensions.
  - Update progress output to show the final renamed path.

  ## Changes

  - Add DetectFileType helper for webp/png/gif/jpg detection.
  - After download completion, rename files when the detected type differs from the current extension.
  - Track and display the final output path in the progress UI.